### PR TITLE
Implement join API

### DIFF
--- a/src/server/functions.rs
+++ b/src/server/functions.rs
@@ -1,16 +1,66 @@
-// Server functions will be implemented here
-// This file will contain Leptos server functions for:
-// - User management (join_room, get_room_state)
-// - Video controls (play_video, pause_video, seek_video)
-// - Queue management (add_to_queue, remove_from_queue)
-// - Chat functions (send_message, get_messages)
+// Server functions for the application
+// Handles user management and room state retrieval
 
 use leptos::*;
+use sqlx::{self};
+use uuid::Uuid;
 use crate::types::*;
+use crate::server::state::AppState;
 
-// Placeholder - will be implemented in Phase 2
 #[server(JoinRoom, "/api")]
 pub async fn join_room(username: String) -> Result<JoinResponse, ServerFnError> {
-    // TODO: Implement user join functionality
-    Err(ServerFnError::ServerError("Not implemented yet".to_string()))
-} 
+    let app_state = expect_context::<AppState>();
+    let user_id = uuid::Uuid::new_v4().to_string();
+
+    sqlx::query(
+        "INSERT INTO users (id, username, is_online) VALUES (?, ?, TRUE)"
+    )
+        .bind(&user_id)
+        .bind(&username)
+        .execute(&app_state.db)
+        .await?;
+
+    let room_state = get_room_state().await?;
+
+    Ok(JoinResponse {
+        user_id,
+        username,
+        room_state,
+    })
+}
+
+#[server(GetRoomState, "/api")]
+pub async fn get_room_state() -> Result<RoomState, ServerFnError> {
+    let app_state = expect_context::<AppState>();
+
+    let current_video = sqlx::query_as::<_, VideoState>(
+        "SELECT * FROM room_state WHERE id = 1"
+    )
+    .fetch_optional(&app_state.db)
+    .await?;
+
+    let queue = sqlx::query_as::<_, QueueItem>(
+        "SELECT * FROM queue ORDER BY position"
+    )
+    .fetch_all(&app_state.db)
+    .await?;
+
+    let users = sqlx::query_as::<_, User>(
+        "SELECT * FROM users WHERE is_online = TRUE"
+    )
+    .fetch_all(&app_state.db)
+    .await?;
+
+    let messages = sqlx::query_as::<_, Message>(
+        "SELECT * FROM messages ORDER BY created_at DESC LIMIT 50"
+    )
+    .fetch_all(&app_state.db)
+    .await?;
+
+    Ok(RoomState {
+        current_video,
+        queue,
+        users,
+        messages,
+    })
+}

--- a/src/types/models.rs
+++ b/src/types/models.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "ssr", derive(sqlx::FromRow))]
 pub struct User {
     pub id: String,
     pub username: String,
@@ -11,6 +12,7 @@ pub struct User {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "ssr", derive(sqlx::FromRow))]
 pub struct QueueItem {
     pub id: i32,
     pub video_id: String,
@@ -24,6 +26,7 @@ pub struct QueueItem {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "ssr", derive(sqlx::FromRow))]
 pub struct Message {
     pub id: i32,
     pub user_id: String,
@@ -34,6 +37,7 @@ pub struct Message {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "ssr", derive(sqlx::FromRow))]
 pub struct VideoState {
     pub id: i32,
     pub current_video_id: Option<String>,


### PR DESCRIPTION
## Summary
- implement `/api/JoinRoom` and `GetRoomState` server functions
- derive `sqlx::FromRow` for models when `ssr` is enabled
- call `join_room` from frontend join modal

## Testing
- `DATABASE_URL=sqlite::memory: cargo check --features ssr`
- `DATABASE_URL=sqlite::memory: cargo check --features hydrate` *(fails: unresolved import `crate::server_fns`)*
- `DATABASE_URL=sqlite::memory: cargo test --features ssr`

------
https://chatgpt.com/codex/tasks/task_e_685a999a5f5883309ed9d1461fa2a3e7