### PR TITLE
Run trunk build with fixes

### DIFF
--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -1,0 +1,24 @@
+#[cfg(not(feature = "ssr"))]
+use crate::types::JoinResponse;
+#[cfg(not(feature = "ssr"))]
+use leptos::ServerFnError;
+#[cfg(not(feature = "ssr"))]
+use gloo_net::http::Request;
+#[cfg(not(feature = "ssr"))]
+use serde_json::json;
+
+#[cfg(not(feature = "ssr"))]
+pub async fn join_room(username: String) -> Result<JoinResponse, ServerFnError<()>> {
+    let body = json!({ "username": username });
+    let resp = Request::post("/api/join_room")
+        .header("Content-Type", "application/json")
+        .body(body.to_string()).map_err(|e| ServerFnError::<()>::Request(e.to_string()))?
+        .send()
+        .await
+        .map_err(|e| ServerFnError::<()>::Request(e.to_string()))?;
+    let data: JoinResponse = resp
+        .json()
+        .await
+        .map_err(|e| ServerFnError::<()>::Deserialization(e.to_string()))?;
+    Ok(data)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ use leptos_router::*;
 mod components;
 mod pages;
 mod types;
+#[cfg(not(feature = "ssr"))]
+mod client_api;
 
 #[cfg(feature = "ssr")]
 pub mod server;

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -2,7 +2,7 @@ use crate::components::{Chat, JoinModal, Queue, UserList, VideoPlayer};
 #[cfg(feature = "ssr")]
 use crate::server::functions::join_room;
 #[cfg(not(feature = "ssr"))]
-use crate::server_functions::join_room;
+use crate::client_api::join_room;
 use gloo_net::http::Request;
 use gloo_timers::future::TimeoutFuture;
 use leptos::logging;


### PR DESCRIPTION
## Summary
- add a small `client_api` module with a stub `join_room` call used when not building with `ssr`
- include new module in `lib.rs`
- update import in `Home` page to use the stub when compiling to wasm

## Testing
- `trunk build --release`

------
https://chatgpt.com/codex/tasks/task_e_685aba3ee4348330a39d475cc554dd23