### PR TITLE
Implement Phase 2 server basics

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -6,6 +6,7 @@ async fn main() {
     use leptos_axum::{generate_route_list, render_app_to_stream_with_context, LeptosRoutes};
     use tower_http::services::ServeDir;
     use youtube_together::server::state::AppState;
+    use youtube_together::server::auth::auth;
     use youtube_together::*;
 
     // Initialize tracing
@@ -45,7 +46,8 @@ async fn main() {
         .nest_service("/longpoll", app_state.long_poll_handler())
         .nest_service("/pkg", ServeDir::new("target/site/pkg"))
         .nest_service("/public", ServeDir::new("public"))
-        .with_state(leptos_options.clone());
+        .with_state(leptos_options.clone())
+        .layer(axum::middleware::from_fn(auth));
 
     // Start the server
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,0 +1,20 @@
+use axum::{body::Body, http::Request, http::StatusCode, middleware::Next, response::Response};
+
+/// Simple authentication middleware that expects an `X-Auth-Token` header.
+/// The header value is inserted into request extensions for handlers to use.
+pub async fn auth(mut req: Request<Body>, next: Next) -> Result<Response, StatusCode> {
+    let token = req
+        .headers()
+        .get("x-auth-token")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    if let Some(token) = token {
+        if !token.is_empty() {
+            req.extensions_mut().insert(token);
+            return Ok(next.run(req).await);
+        }
+    }
+
+    Err(StatusCode::UNAUTHORIZED)
+}

--- a/src/server/database.rs
+++ b/src/server/database.rs
@@ -8,12 +8,54 @@
 #[cfg(feature = "ssr")]
 use sqlx::{Pool, Sqlite};
 
-// Placeholder - will be implemented in Phase 2
-pub struct DatabaseOperations;
+#[cfg(feature = "ssr")]
+use crate::types::{RoomState, User, VideoState, QueueItem, Message};
+
+/// Convenience wrapper around the database connection pool.
+#[cfg_attr(feature = "ssr", derive(Clone))]
+pub struct DatabaseOperations {
+    pub db: Pool<Sqlite>,
+}
 
 impl DatabaseOperations {
-    pub async fn new(_db: Pool<Sqlite>) -> Self {
-        // TODO: Initialize database operations
-        Self
+    /// Create a new [`DatabaseOperations`] instance.
+    pub async fn new(db: Pool<Sqlite>) -> Self {
+        Self { db }
     }
-} 
+
+    /// Insert a new user into the database.
+    pub async fn add_user(&self, id: &str, username: &str) -> Result<(), sqlx::Error> {
+        sqlx::query("INSERT INTO users (id, username, is_online) VALUES (?, ?, TRUE)")
+            .bind(id)
+            .bind(username)
+            .execute(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    /// Fetch the current [`RoomState`].
+    pub async fn get_room_state(&self) -> Result<RoomState, sqlx::Error> {
+        let current_video = sqlx::query_as::<_, VideoState>("SELECT * FROM room_state WHERE id = 1")
+            .fetch_optional(&self.db)
+            .await?;
+
+        let queue = sqlx::query_as::<_, QueueItem>("SELECT * FROM queue ORDER BY position")
+            .fetch_all(&self.db)
+            .await?;
+
+        let users = sqlx::query_as::<_, User>("SELECT * FROM users WHERE is_online = TRUE")
+            .fetch_all(&self.db)
+            .await?;
+
+        let messages = sqlx::query_as::<_, Message>("SELECT * FROM messages ORDER BY created_at DESC LIMIT 50")
+            .fetch_all(&self.db)
+            .await?;
+
+        Ok(RoomState {
+            current_video,
+            queue,
+            users,
+            messages,
+        })
+    }
+}

--- a/src/server/events.rs
+++ b/src/server/events.rs
@@ -5,16 +5,27 @@
 // - Real-time synchronization
 
 use crate::types::Event;
+use tokio::sync::broadcast;
 
-// Placeholder - will be implemented in Phase 2
-pub struct EventManager;
+/// Simple manager around a broadcast channel for SSE events.
+pub struct EventManager {
+    sender: broadcast::Sender<Event>,
+}
 
 impl EventManager {
+    /// Create a new [`EventManager`] with a reasonable buffer size.
     pub fn new() -> Self {
-        Self
+        let (sender, _) = broadcast::channel(1000);
+        Self { sender }
     }
 
-    pub async fn broadcast_event(&self, _event: Event) {
-        // TODO: Implement event broadcasting
+    /// Subscribe to the event stream.
+    pub fn subscribe(&self) -> broadcast::Receiver<Event> {
+        self.sender.subscribe()
     }
-} 
+
+    /// Broadcast an event to all subscribers.
+    pub fn broadcast_event(&self, event: Event) {
+        let _ = self.sender.send(event);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,4 +2,5 @@ pub mod state;
 pub mod functions;
 pub mod database;
 pub mod youtube;
-pub mod events; 
+pub mod events;
+pub mod auth;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,15 @@
+use youtube_together::server::{functions::join_room, state::AppState};
+use leptos::*;
+
+#[tokio::test]
+async fn test_join_room_inserts_user() {
+    std::env::set_var("DATABASE_URL", "sqlite::memory:");
+    let state = AppState::new().await.expect("create state");
+    let runtime = leptos::create_runtime();
+    provide_context(state.clone());
+
+    let resp = join_room("Alice".to_string()).await.expect("join");
+    assert_eq!(resp.username, "Alice");
+    assert_eq!(resp.room_state.users.len(), 1);
+    runtime.dispose();
+}


### PR DESCRIPTION
## Summary
- flesh out EventManager for broadcasting events
- add DatabaseOperations helper with room state queries
- introduce simple auth middleware and apply it to server routes
- wire new modules
- add integration test for `join_room`

## Testing
- `cargo test --features ssr`

------
https://chatgpt.com/codex/tasks/task_e_685ac3845ca48330a222008f2a2ac349