### PR TITLE
Implement basic API endpoints

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -5,6 +5,10 @@
 import * as $_404 from "./routes/_404.tsx";
 import * as $_app from "./routes/_app.tsx";
 import * as $api_joke from "./routes/api/joke.ts";
+import * as $current_state from "./routes/current-state.ts";
+import * as $join from "./routes/join.ts";
+import * as $request_video from "./routes/request-video.ts";
+import * as $update_mode from "./routes/update-mode.ts";
 import * as $greet_name_ from "./routes/greet/[name].tsx";
 import * as $index from "./routes/index.tsx";
 import * as $Counter from "./islands/Counter.tsx";
@@ -15,6 +19,10 @@ const manifest = {
     "./routes/_404.tsx": $_404,
     "./routes/_app.tsx": $_app,
     "./routes/api/joke.ts": $api_joke,
+    "./routes/current-state.ts": $current_state,
+    "./routes/join.ts": $join,
+    "./routes/request-video.ts": $request_video,
+    "./routes/update-mode.ts": $update_mode,
     "./routes/greet/[name].tsx": $greet_name_,
     "./routes/index.tsx": $index,
   },

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,0 +1,3 @@
+export async function getKv() {
+  return await Deno.openKv();
+}

--- a/routes/current-state.ts
+++ b/routes/current-state.ts
@@ -1,0 +1,16 @@
+import { Handlers } from "$fresh/server.ts";
+import { getKv } from "../lib/kv.ts";
+
+export const handler: Handlers = {
+  async GET() {
+    const kv = await getKv();
+    const { value: state } = await kv.get(["room:state"]);
+    const queue: unknown[] = [];
+    for await (const entry of kv.list({ prefix: ["queue"] })) {
+      queue.push(entry.value);
+    }
+    return new Response(JSON.stringify({ state, queue }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+};

--- a/routes/join.ts
+++ b/routes/join.ts
@@ -1,0 +1,24 @@
+import { Handlers } from "$fresh/server.ts";
+import { getKv } from "../lib/kv.ts";
+
+export const handler: Handlers = {
+  async POST(req) {
+    const { name } = await req.json();
+    if (!name || typeof name !== "string") {
+      return new Response(JSON.stringify({ error: "name required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const id = crypto.randomUUID();
+    const kv = await getKv();
+    await kv.set(["users", id], {
+      id,
+      name,
+      joinedAt: new Date().toISOString(),
+    });
+    return new Response(JSON.stringify({ id }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+};

--- a/routes/request-video.ts
+++ b/routes/request-video.ts
@@ -1,0 +1,26 @@
+import { Handlers } from "$fresh/server.ts";
+import { getKv } from "../lib/kv.ts";
+
+export const handler: Handlers = {
+  async POST(req) {
+    const { videoId, userId, title, duration, thumbnail } = await req.json();
+    if (!videoId || typeof videoId !== "string" || !userId) {
+      return new Response(JSON.stringify({ error: "invalid request" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const ts = Date.now();
+    const kv = await getKv();
+    await kv.set(["queue", ts, videoId], {
+      videoId,
+      title,
+      requestedBy: userId,
+      duration,
+      thumbnail,
+    });
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+};

--- a/routes/update-mode.ts
+++ b/routes/update-mode.ts
@@ -1,0 +1,26 @@
+import { Handlers } from "$fresh/server.ts";
+import { getKv } from "../lib/kv.ts";
+
+export const handler: Handlers = {
+  async POST(req) {
+    const { mode } = await req.json();
+    if (mode !== "video" && mode !== "radio") {
+      return new Response(JSON.stringify({ error: "invalid mode" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const kv = await getKv();
+    const { value: state } = await kv.get(["room:state"]);
+    const newState = {
+      currentVideoId: state?.currentVideoId ?? null,
+      playbackTime: state?.playbackTime ?? 0,
+      mode,
+      lastUpdated: new Date().toISOString(),
+    };
+    await kv.set(["room:state"], newState);
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- add Deno KV helper
- implement `/join`, `/request-video`, `/current-state`, and `/update-mode` API routes
- register new routes in `fresh.gen.ts`

## Testing
- `deno fmt routes/join.ts routes/request-video.ts routes/current-state.ts routes/update-mode.ts lib/kv.ts fresh.gen.ts`
- `deno fmt --check`
- `deno lint`
- `deno check **/*.ts` *(fails: invalid peer certificate)*
- `deno task manifest` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_686691efaa6483308724df83a6de4346