### PR TITLE
Implement join and room frontend

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -9,9 +9,12 @@ import * as $current_state from "./routes/current-state.ts";
 import * as $join from "./routes/join.ts";
 import * as $request_video from "./routes/request-video.ts";
 import * as $update_mode from "./routes/update-mode.ts";
+import * as $room from "./routes/room.tsx";
 import * as $greet_name_ from "./routes/greet/[name].tsx";
 import * as $index from "./routes/index.tsx";
 import * as $Counter from "./islands/Counter.tsx";
+import * as $JoinForm from "./islands/JoinForm.tsx";
+import * as $Room from "./islands/Room.tsx";
 import type { Manifest } from "$fresh/server.ts";
 
 const manifest = {
@@ -23,11 +26,14 @@ const manifest = {
     "./routes/join.ts": $join,
     "./routes/request-video.ts": $request_video,
     "./routes/update-mode.ts": $update_mode,
+    "./routes/room.tsx": $room,
     "./routes/greet/[name].tsx": $greet_name_,
     "./routes/index.tsx": $index,
   },
   islands: {
     "./islands/Counter.tsx": $Counter,
+    "./islands/JoinForm.tsx": $JoinForm,
+    "./islands/Room.tsx": $Room,
   },
   baseUrl: import.meta.url,
 } satisfies Manifest;

--- a/islands/JoinForm.tsx
+++ b/islands/JoinForm.tsx
@@ -1,0 +1,42 @@
+import { useState } from "preact/hooks";
+import { Button } from "../components/Button.tsx";
+
+export default function JoinForm() {
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const join = async (e: Event) => {
+    e.preventDefault();
+    if (!name) return;
+    try {
+      const resp = await fetch("/join", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        localStorage.setItem("userId", data.id);
+        location.href = "/room";
+      } else {
+        setError(data.error || "Failed to join");
+      }
+    } catch (_err) {
+      setError("Failed to join");
+    }
+  };
+
+  return (
+    <form onSubmit={join} class="flex gap-4">
+      <input
+        class="border-2 px-2 py-1"
+        type="text"
+        placeholder="Your name"
+        value={name}
+        onInput={(e) => setName((e.target as HTMLInputElement).value)}
+      />
+      <Button type="submit">Join</Button>
+      {error && <p class="text-red-600">{error}</p>}
+    </form>
+  );
+}

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "preact/hooks";
+import { Button } from "../components/Button.tsx";
+
+interface QueueItem {
+  videoId: string;
+  title?: string;
+  thumbnail?: string;
+}
+
+interface RoomState {
+  currentVideoId: string | null;
+  mode: "video" | "radio";
+  playbackTime: number;
+}
+
+export default function Room() {
+  const [state, setState] = useState<RoomState | null>(null);
+  const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [videoId, setVideoId] = useState("");
+  const userId = typeof window !== "undefined"
+    ? localStorage.getItem("userId")
+    : "";
+
+  const fetchState = async () => {
+    try {
+      const resp = await fetch("/current-state");
+      const data = await resp.json();
+      setState(data.state);
+      setQueue(data.queue || []);
+    } catch (_e) {
+      // ignore network errors
+    }
+  };
+
+  useEffect(() => {
+    let running = true;
+    const poll = async () => {
+      while (running) {
+        await fetchState();
+        await new Promise((r) => setTimeout(r, 3000));
+      }
+    };
+    poll();
+    return () => {
+      running = false;
+    };
+  }, []);
+
+  const submit = async (e: Event) => {
+    e.preventDefault();
+    if (!videoId) return;
+    try {
+      await fetch("/request-video", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ videoId, userId }),
+      });
+      setVideoId("");
+      fetchState();
+    } catch (_e) {
+      // ignore network errors
+    }
+  };
+
+  return (
+    <div class="space-y-4">
+      <form onSubmit={submit} class="flex gap-2">
+        <input
+          class="border-2 px-2 py-1 flex-grow"
+          value={videoId}
+          onInput={(e) => setVideoId((e.target as HTMLInputElement).value)}
+          placeholder="YouTube video ID"
+        />
+        <Button type="submit">Request</Button>
+      </form>
+
+      {state?.currentVideoId && (
+        <div class="mt-4">
+          <iframe
+            width="560"
+            height="315"
+            src={`https://www.youtube.com/embed/${state.currentVideoId}?autoplay=1`}
+            allow="autoplay"
+          />
+        </div>
+      )}
+
+      <div>
+        <h2 class="font-bold">Queue</h2>
+        <ul>
+          {queue.map((item) => (
+            <li key={item.videoId}>{item.title || item.videoId}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,24 +1,18 @@
-import { useSignal } from "@preact/signals";
-import Counter from "../islands/Counter.tsx";
+import JoinForm from "../islands/JoinForm.tsx";
 
 export default function Home() {
-  const count = useSignal(3);
   return (
     <div class="px-4 py-8 mx-auto bg-[#86efac]">
-      <div class="max-w-screen-md mx-auto flex flex-col items-center justify-center">
+      <div class="max-w-screen-md mx-auto flex flex-col items-center justify-center gap-4">
         <img
           class="my-6"
           src="/logo.svg"
           width="128"
           height="128"
-          alt="the Fresh logo: a sliced lemon dripping with juice"
+          alt="logo"
         />
-        <h1 class="text-4xl font-bold">Welcome to Fresh</h1>
-        <p class="my-4">
-          Try updating this message in the
-          <code class="mx-2">./routes/index.tsx</code> file, and refresh.
-        </p>
-        <Counter count={count} />
+        <h1 class="text-4xl font-bold">Join the Radio Room</h1>
+        <JoinForm />
       </div>
     </div>
   );

--- a/routes/room.tsx
+++ b/routes/room.tsx
@@ -1,0 +1,9 @@
+import Room from "../islands/Room.tsx";
+
+export default function RoomPage() {
+  return (
+    <div class="p-4">
+      <Room />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `JoinForm` and `Room` islands for UI interactivity
- replace index page with a join form
- add `room` page for video playback and queue
- register new pages and islands in `fresh.gen.ts`

## Testing
- `deno fmt --check`
- `deno lint`
- `deno check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_686693e6f7708330b093bfab5172db30