### PR TITLE
Implement basic long polling

### DIFF
--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -16,6 +16,7 @@ interface RoomState {
 export default function Room() {
   const [state, setState] = useState<RoomState | null>(null);
   const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [counter, setCounter] = useState(0);
   const [videoId, setVideoId] = useState("");
   const userId = typeof window !== "undefined"
     ? localStorage.getItem("userId")
@@ -23,10 +24,11 @@ export default function Room() {
 
   const fetchState = async () => {
     try {
-      const resp = await fetch("/current-state");
+      const resp = await fetch(`/current-state?since=${counter}`);
       const data = await resp.json();
       setState(data.state);
       setQueue(data.queue || []);
+      setCounter(data.counter || 0);
     } catch (_e) {
       // ignore network errors
     }
@@ -37,7 +39,7 @@ export default function Room() {
     const poll = async () => {
       while (running) {
         await fetchState();
-        await new Promise((r) => setTimeout(r, 3000));
+        await new Promise((r) => setTimeout(r, 1000));
       }
     };
     poll();

--- a/lib/updateNotifier.ts
+++ b/lib/updateNotifier.ts
@@ -1,0 +1,30 @@
+let counter = 0;
+const listeners = new Set<() => void>();
+
+export function getCounter() {
+  return counter;
+}
+
+export function notifyUpdate() {
+  counter++;
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch (_) {
+      // ignore listener errors
+    }
+  }
+}
+
+export function waitForUpdate(last: number, timeout = 25000): Promise<void> {
+  if (counter > last) return Promise.resolve();
+  return new Promise((resolve) => {
+    const onUpdate = () => {
+      listeners.delete(onUpdate);
+      clearTimeout(timer);
+      resolve();
+    };
+    listeners.add(onUpdate);
+    const timer = setTimeout(onUpdate, timeout);
+  });
+}

--- a/routes/current-state.ts
+++ b/routes/current-state.ts
@@ -1,16 +1,26 @@
 import { Handlers } from "$fresh/server.ts";
 import { getKv } from "../lib/kv.ts";
+import { getCounter, waitForUpdate } from "../lib/updateNotifier.ts";
 
 export const handler: Handlers = {
-  async GET() {
+  async GET(req) {
+    const url = new URL(req.url);
+    const since = Number(url.searchParams.get("since") ?? 0);
+    if (since < getCounter()) {
+      // respond immediately
+    } else {
+      await waitForUpdate(since);
+    }
+
     const kv = await getKv();
     const { value: state } = await kv.get(["room:state"]);
     const queue: unknown[] = [];
     for await (const entry of kv.list({ prefix: ["queue"] })) {
       queue.push(entry.value);
     }
-    return new Response(JSON.stringify({ state, queue }), {
-      headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ state, queue, counter: getCounter() }),
+      { headers: { "Content-Type": "application/json" } },
+    );
   },
 };

--- a/routes/request-video.ts
+++ b/routes/request-video.ts
@@ -1,5 +1,6 @@
 import { Handlers } from "$fresh/server.ts";
 import { getKv } from "../lib/kv.ts";
+import { notifyUpdate } from "../lib/updateNotifier.ts";
 
 export const handler: Handlers = {
   async POST(req) {
@@ -19,6 +20,7 @@ export const handler: Handlers = {
       duration,
       thumbnail,
     });
+    notifyUpdate();
     return new Response(JSON.stringify({ ok: true }), {
       headers: { "Content-Type": "application/json" },
     });

--- a/routes/update-mode.ts
+++ b/routes/update-mode.ts
@@ -1,5 +1,6 @@
 import { Handlers } from "$fresh/server.ts";
 import { getKv } from "../lib/kv.ts";
+import { notifyUpdate } from "../lib/updateNotifier.ts";
 
 export const handler: Handlers = {
   async POST(req) {
@@ -19,6 +20,7 @@ export const handler: Handlers = {
       lastUpdated: new Date().toISOString(),
     };
     await kv.set(["room:state"], newState);
+    notifyUpdate();
     return new Response(JSON.stringify({ ok: true }), {
       headers: { "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- add in-memory update notifier
- update queue & mode routes to broadcast updates
- implement long polling endpoint logic
- poll from the room island using `since` marker

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6868e6218fb0833086cd1e9a05a08274