### PR TITLE
Improve user redirect

### DIFF
--- a/islands/JoinForm.tsx
+++ b/islands/JoinForm.tsx
@@ -1,9 +1,31 @@
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { Button } from "../components/Button.tsx";
 
 export default function JoinForm() {
   const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    const id = localStorage.getItem("userId");
+    if (!id) {
+      setChecked(true);
+      return;
+    }
+    fetch(`/api/validate-user?id=${id}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.valid) {
+          location.href = "/room";
+        } else {
+          localStorage.removeItem("userId");
+          setChecked(true);
+        }
+      })
+      .catch(() => {
+        setChecked(true);
+      });
+  }, []);
 
   const join = async (e: Event) => {
     e.preventDefault();
@@ -25,6 +47,10 @@ export default function JoinForm() {
       setError("Failed to join");
     }
   };
+
+  if (!checked) {
+    return <div />;
+  }
 
   return (
     <form onSubmit={join} class="flex gap-2 w-full">

--- a/routes/api/validate-user.ts
+++ b/routes/api/validate-user.ts
@@ -1,0 +1,20 @@
+import { Handlers } from "$fresh/server.ts";
+import { getKv } from "../../lib/kv.ts";
+
+export const handler: Handlers = {
+  async GET(req) {
+    const url = new URL(req.url);
+    const id = url.searchParams.get("id");
+    if (!id) {
+      return new Response(JSON.stringify({ valid: false }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const kv = await getKv();
+    const { value } = await kv.get(["users", id]);
+    const valid = Boolean(value);
+    return new Response(JSON.stringify({ valid }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+};

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,4 +1,26 @@
 import JoinForm from "../islands/JoinForm.tsx";
+import { Handlers } from "$fresh/server.ts";
+import { getKv } from "../lib/kv.ts";
+
+export const handler: Handlers = {
+  async GET(req, ctx) {
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+    if (ip) {
+      const kv = await getKv();
+      for await (
+        const entry of kv.list<{ ip?: string }>({ prefix: ["users"] })
+      ) {
+        if (entry.value.ip === ip) {
+          return new Response(null, {
+            status: 307,
+            headers: { location: "/room" },
+          });
+        }
+      }
+    }
+    return ctx.render();
+  },
+};
 
 export default function Home() {
   return (

--- a/routes/join.ts
+++ b/routes/join.ts
@@ -10,12 +10,14 @@ export const handler: Handlers = {
         headers: { "Content-Type": "application/json" },
       });
     }
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
     const id = crypto.randomUUID();
     const kv = await getKv();
     await kv.set(["users", id], {
       id,
       name,
       joinedAt: new Date().toISOString(),
+      ip,
     });
     return new Response(JSON.stringify({ id }), {
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- store user IP when joining
- auto redirect if user has joined before
- add `/api/validate-user` route to confirm stored ID

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_686bab3bfa8883309028e4388214af55