### PR TITLE
Add /add chat command for video requests

### DIFF
--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -25,7 +25,6 @@ export default function Room() {
   const [queue, setQueue] = useState<QueueItem[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [counter, setCounter] = useState(0);
-  const [videoId, setVideoId] = useState("");
   const [chatText, setChatText] = useState("");
   const userId = typeof window !== "undefined"
     ? localStorage.getItem("userId")
@@ -58,22 +57,6 @@ export default function Room() {
     };
   }, []);
 
-  const submit = async (e: Event) => {
-    e.preventDefault();
-    if (!videoId) return;
-    try {
-      await fetch("/request-video", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ videoId, userId }),
-      });
-      setVideoId("");
-      fetchState();
-    } catch (_e) {
-      // ignore network errors
-    }
-  };
-
   const sendChat = async (e: Event) => {
     e.preventDefault();
     if (!chatText) return;
@@ -91,17 +74,11 @@ export default function Room() {
   };
 
   return (
-    <div class="flex gap-4 h-screen p-4 box-border">
+    <div class="flex flex-col sm:flex-row gap-4 h-screen p-4 box-border">
       <div class="flex flex-col flex-1">
-        <form onSubmit={submit} class="flex gap-2 mb-4">
-          <input
-            class="flex-grow border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            value={videoId}
-            onInput={(e) => setVideoId((e.target as HTMLInputElement).value)}
-            placeholder="YouTube video ID"
-          />
-          <Button type="submit">Request</Button>
-        </form>
+        <p class="mb-4 text-sm text-gray-600">
+          Use <code>/add &lt;YouTube URL&gt;</code> in chat to request a video.
+        </p>
         <div class="flex-1 flex items-center justify-center">
           {state?.currentVideoId && (
             <iframe
@@ -123,7 +100,7 @@ export default function Room() {
           </ul>
         </div>
       </div>
-      <div class="w-64 border-l pl-4 flex flex-col">
+      <div class="w-full sm:w-64 border-t sm:border-t-0 sm:border-l pt-4 sm:pt-0 sm:pl-4 flex flex-col">
         <h2 class="font-bold mb-2">Chat</h2>
         <div class="flex-1 overflow-y-auto mb-2 space-y-1">
           {messages.map((m) => (

--- a/routes/send-message.ts
+++ b/routes/send-message.ts
@@ -2,6 +2,49 @@ import { Handlers } from "$fresh/server.ts";
 import { getKv } from "../lib/kv.ts";
 import { notifyUpdate } from "../lib/updateNotifier.ts";
 
+async function extractVideoInfo(videoId: string) {
+  const apiKey = Deno.env.get("YOUTUBE_API_KEY");
+  if (!apiKey) return null;
+  const url =
+    `https://www.googleapis.com/youtube/v3/videos?id=${videoId}&part=snippet,contentDetails&key=${apiKey}`;
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const item = data.items?.[0];
+    if (!item) return null;
+    const duration = item.contentDetails?.duration as string | undefined;
+    const m = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/.exec(duration ?? "");
+    const seconds = m
+      ? ((Number(m[1]) || 0) * 3600) + ((Number(m[2]) || 0) * 60) +
+        (Number(m[3]) || 0)
+      : 0;
+    return {
+      title: item.snippet?.title as string | undefined,
+      thumbnail: item.snippet?.thumbnails?.default?.url as string | undefined,
+      duration: seconds,
+    };
+  } catch (_e) {
+    return null;
+  }
+}
+
+function extractVideoId(text: string): string | null {
+  try {
+    const url = new URL(text);
+    if (url.hostname === "youtu.be") {
+      return url.pathname.slice(1);
+    }
+    if (url.hostname.includes("youtube.com")) {
+      return url.searchParams.get("v");
+    }
+  } catch (_e) {
+    // not a URL, maybe plain ID
+  }
+  if (/^[a-zA-Z0-9_-]{11}$/.test(text)) return text;
+  return null;
+}
+
 export const handler: Handlers = {
   async POST(req) {
     const { text, userId } = await req.json();
@@ -16,6 +59,20 @@ export const handler: Handlers = {
     const userName = user?.name ?? "Unknown";
     const ts = Date.now();
     await kv.set(["chat", ts], { userId, userName, text, ts });
+    if (text.startsWith("/add ")) {
+      const arg = text.slice(5).trim();
+      const videoId = extractVideoId(arg);
+      if (videoId) {
+        const info = await extractVideoInfo(videoId);
+        await kv.set(["queue", Date.now(), videoId], {
+          videoId,
+          title: info?.title,
+          requestedBy: userId,
+          duration: info?.duration,
+          thumbnail: info?.thumbnail,
+        });
+      }
+    }
     notifyUpdate();
     return new Response(JSON.stringify({ ok: true }), {
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- remove direct video request input from room UI
- show help text describing `/add` command
- parse `/add` chat messages server-side and fetch video info from the YouTube API
- adjust layout for better responsiveness

## Testing
- `deno fmt islands/Room.tsx routes/send-message.ts`
- `deno lint islands/Room.tsx routes/send-message.ts`
- `deno check routes/send-message.ts islands/Room.tsx` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_686cb4fed3dc833090419815d6507bf3