### PR TITLE
Improve mobile layout

### DIFF
--- a/islands/JoinForm.tsx
+++ b/islands/JoinForm.tsx
@@ -53,16 +53,20 @@ export default function JoinForm() {
   }
 
   return (
-    <form onSubmit={join} class="flex gap-2 w-full">
+    <form onSubmit={join} class="flex flex-col sm:flex-row gap-2 w-full">
       <input
-        class="flex-grow border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        class="w-full sm:flex-grow border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
         type="text"
         placeholder="Your name"
         value={name}
         onInput={(e) => setName((e.target as HTMLInputElement).value)}
       />
-      <Button type="submit">Join</Button>
-      {error && <p class="text-red-600 text-sm ml-2 self-center">{error}</p>}
+      <Button type="submit" class="w-full sm:w-auto">Join</Button>
+      {error && (
+        <p class="text-red-600 text-sm mt-2 sm:ml-2 sm:mt-0 self-center">
+          {error}
+        </p>
+      )}
     </form>
   );
 }

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -74,19 +74,20 @@ export default function Room() {
   };
 
   return (
-    <div class="flex flex-col sm:flex-row gap-4 h-screen p-4 box-border">
+    <div class="flex flex-col sm:flex-row gap-4 min-h-screen p-4 box-border">
       <div class="flex flex-col flex-1">
         <p class="mb-4 text-sm text-gray-600">
           Use <code>/add &lt;YouTube URL&gt;</code> in chat to request a video.
         </p>
         <div class="flex-1 flex items-center justify-center">
           {state?.currentVideoId && (
-            <iframe
-              width="560"
-              height="315"
-              src={`https://www.youtube.com/embed/${state.currentVideoId}?autoplay=1`}
-              allow="autoplay"
-            />
+            <div class="w-full aspect-video">
+              <iframe
+                class="w-full h-full"
+                src={`https://www.youtube.com/embed/${state.currentVideoId}?autoplay=1`}
+                allow="autoplay"
+              />
+            </div>
           )}
         </div>
         <div class="mt-4">


### PR DESCRIPTION
## Summary
- Make video player responsive and switch layout height to `min-h-screen`
- Stack join form inputs vertically on small screens

## Testing
- `deno fmt islands/Room.tsx islands/JoinForm.tsx`
- `deno lint islands/Room.tsx islands/JoinForm.tsx`
- `deno test` *(fails: No test modules found)*

------
https://chatgpt.com/codex/tasks/task_e_689882667ab4832f99d3e2e7145a0c6b